### PR TITLE
feat: replace uses of Reify, upgrade clojure, upgrade manifold lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This is a history of changes to k13labs/futurama
 
+# 1.0.4
+* replace uses of Reify with JavaFunction and JavaBiConsumer types
+* upgrade clojure version to 1.11.4
+
 # 1.0.3
 * upgrade clojure version to 1.11.2
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.11.2"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.4"}
         org.clojure/core.async {:mvn/version "1.6.681"}
-        manifold/manifold {:mvn/version "0.4.1"}}
+        manifold/manifold {:mvn/version "0.4.3"}}
 
  ;for more examples of aliases see: https://github.com/seancorfield/dot-clojure
  :aliases

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.k13labs</groupId>
   <artifactId>futurama</artifactId>
   <name>futurama</name>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <scm>
-    <tag>1.0.3</tag>
+    <tag>1.0.4</tag>
     <url>https://github.com/k13labs/futurama</url>
     <connection>scm:git:git://github.com/k13labs/futurama.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/k13labs/futurama.git</developerConnection>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.2</version>
+      <version>1.11.4</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>manifold</groupId>
       <artifactId>manifold</artifactId>
-      <version>0.4.1</version>
+      <version>0.4.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -24,7 +24,7 @@
 
 (deftype JavaFunction [f]
   Function
-  (apply [this a]
+  (apply [_ a]
     (f a)))
 
 (deftype JavaBiConsumer [f]

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -22,6 +22,16 @@
            [java.util.function Function BiConsumer]
            [manifold.deferred Deferred]))
 
+(deftype JavaFunction [f]
+  Function
+  (apply [this a]
+    (f a)))
+
+(deftype JavaBiConsumer [f]
+  BiConsumer
+  (accept [_ a b]
+    (f a b)))
+
 (def ^:const ASYNC_CANCELLED ::cancelled)
 
 (def ^:dynamic *thread-pool* nil)
@@ -180,8 +190,8 @@
                                                    (finally
                                                      (Var/resetThreadBindingFrame thread-frame#))))) ;;; restore the original Thread's binding frame
                             ^Future fut# (dispatch fbody#)
-                            ^Function cancel# (reify Function
-                                                (apply [~'_ ~'_]
+                            ^Function cancel# (JavaFunction.
+                                                (fn [~'_]
                                                   (async-cancel! res-fut#)
                                                   (future-cancel fut#)))] ;;; submit the work to the pool and get the FutureTask doing the work
          ;;; if the CompletableFuture returns exceptionally
@@ -300,8 +310,8 @@
   (completed? [fut]
     (.isDone ^CompletableFuture fut))
   (on-complete [fut f]
-    (let [^BiConsumer invoke-cb (reify BiConsumer
-                                  (accept [_ val ex]
+    (let [^BiConsumer invoke-cb (JavaBiConsumer.
+                                  (fn [val ex]
                                     (f (or ex val))))]
       (.whenComplete ^CompletableFuture fut ^BiConsumer invoke-cb)))
 
@@ -382,8 +392,8 @@
                                                             (ioc/run-state-machine-wrapped state#)))
                               ^Future fut# (dispatch task#)]
                           (when (instance? CompletableFuture c#)
-                            (let [^Function cancel# (reify Function
-                                                      (apply [~'_ ~'_]
+                            (let [^Function cancel# (JavaFunction.
+                                                      (fn [~'_]
                                                         (async-cancel! c#)
                                                         (future-cancel fut#)))]
                               (.exceptionally ^CompletableFuture c#

--- a/test/futurama/core_test.clj
+++ b/test/futurama/core_test.clj
@@ -302,7 +302,7 @@
                    {:verbose true}))
           [mean [lower upper]] (:mean bench)]
       (report-result bench)
-      (is (<= 0.05 lower mean upper 0.07)))))
+      (is (<= 0.04 lower mean upper 0.07)))))
 
 (deftest async-for-test
   (testing "can loop for concurrently, performance test"
@@ -320,7 +320,7 @@
                    {:verbose true}))
           [mean [lower upper]] (:mean bench)]
       (report-result bench)
-      (is (<= 0.05 lower mean upper 0.07)))))
+      (is (<= 0.04 lower mean upper 0.07)))))
 
 (deftest async-ops
   (testing "async? for CompletableFuture"


### PR DESCRIPTION
- replace uses of reify for java Function and BiConsumer interfaces with concrete types
- upgrade clojure to 1.11.4
- upgrade manifold lib to 0.4.3