### PR TITLE
chore: add utility function to easily convert values to futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 This is a history of changes to gateless/futurama
 
 # 1.4.1
+* **Feature**: Add utility `->future` function to easily convert values to future.
+
+# 1.4.1
 * **Bug Fix**: Ensure future is only cancelled if async item was cancelled.
 
 # 1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 This is a history of changes to gateless/futurama
 
-# 1.4.1
+# 1.4.2
 * **Feature**: Add utility `->future` function to easily convert values to future.
 
 # 1.4.1

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -807,7 +807,7 @@
     (let [^BiConsumer invoke-cb (impl/->JavaBiConsumer
                                  (fn [_ _]
                                    (when (impl/cancelled? fut)
-                                     (future-cancel fut'))))] ;;; cancel any linked future
+                                     (impl/cancel! fut'))))] ;;; cancel any linked future
       (.whenComplete ^CompletableFuture fut ^BiConsumer invoke-cb)
       fut))
   (cancel! [fut]
@@ -861,7 +861,7 @@
   (on-cancel-interrupt [dfd fut]
     (let [interrupt-handler (fn [_]
                               (when (impl/cancelled? dfd)
-                                (future-cancel fut)))]
+                                (impl/cancel! fut)))]
       (d/on-realized dfd interrupt-handler interrupt-handler)
       dfd))
   (cancelled? [dfd]
@@ -889,7 +889,7 @@
                (instance? PromiseBuffer))
       (async/take! c (fn [_]
                        (when (impl/cancelled? c)
-                         (future-cancel fut)))))
+                         (impl/cancel! fut)))))
     c)
   (cancelled? [c]
     (get-cancel-state c)))
@@ -905,6 +905,7 @@
 
     (async? val)
     (let [fut (CompletableFuture.)]
+      (impl/on-cancel-interrupt fut val)
       (async
         (try
           (let [res (!<! val)]

--- a/test/futurama/core_test.clj
+++ b/test/futurama/core_test.clj
@@ -51,6 +51,31 @@
     (Executors/newFixedThreadPool 10)))
 
 (deftest cancel-async-test
+  (testing "cancellable ->future is interrupted test"
+    (with-pool @test-pool
+      (let [interrupted (atom false)
+            a (promise)
+            s (atom 0)
+            f (future
+                (try
+                  (while (not (async-cancelled?)) ;;; this loop goes on infinitely until the thread is interrupted
+                    (Thread/sleep 90)
+                    (println "thread looping..." (swap! s inc)))
+                  (println "ended thread looping.")
+                  (deliver a true)
+                  (catch InterruptedException e
+                    (println "interrupted looping by:" (type e))
+                    (reset! interrupted true)
+                    (deliver a true))))
+            f' (f/->future f)]
+        (is (true? (async-cancellable? f)))
+        (go
+          (<! (timeout 100))
+          (async-cancel! f')) ;;; cancelling the ->future causes the converted async object to be interrupted
+        (is (true? @a))
+        (is (true? (async-cancelled? f)))
+        (is (true? (async-completed? f)))
+        (is (true? @interrupted)))))
   (testing "cancellable future is interrupted test"
     (with-pool @test-pool
       (let [interrupted (atom false)
@@ -514,9 +539,12 @@
                    ::result))))))))
 
 (deftest test-future-conversion
-  (testing "can convert any async result to CompletableFuture"
+  (testing "can convert any async result to CompletableFuture - success"
     (let [fut (f/->future (async ::foobar))]
       (is (= ::foobar @fut))))
+  (testing "can convert any async result to CompletableFuture - failure"
+    (let [fut (f/->future (async (throw (ex-info "foobar" {}))))]
+      (is (thrown-with-msg? Exception #"foobar" @fut))))
   (testing "can convert any thread result to CompletableFuture"
     (let [fut (f/->future (thread ::foobar))]
       (is (= ::foobar @fut))))

--- a/test/futurama/core_test.clj
+++ b/test/futurama/core_test.clj
@@ -512,3 +512,20 @@
             (!<! (async
                    (throw (ex-info "foobar" {}))
                    ::result))))))))
+
+(deftest test-future-conversion
+  (testing "can convert any async result to CompletableFuture"
+    (let [fut (f/->future (async ::foobar))]
+      (is (= ::foobar @fut))))
+  (testing "can convert any thread result to CompletableFuture"
+    (let [fut (f/->future (thread ::foobar))]
+      (is (= ::foobar @fut))))
+  (testing "can use CompletableFuture as CompletableFuture"
+    (let [fut' (CompletableFuture/completedFuture ::foobar)
+          fut (f/->future fut')]
+      (is (= ::foobar @fut))
+      (is (identical? fut' fut))))
+  (testing "can use non-async value as CompletableFuture"
+    (let [val ::foobar
+          fut (f/->future val)]
+      (is (= ::foobar @fut)))))


### PR DESCRIPTION
Needed in some cases where it is more convenient to have a future instead of a channel, especially when dealing with telemere.