### PR TITLE
Impl async executor

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        java_version: [corretto-24]
+        java_version: [corretto-25]
         test_clojure_alias: [clojure-1.12]
         test_core_async_alias: [core.async-1.8, core.async-1.9]
       fail-fast: false

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
-[alias]
+[tool_alias]
 clojure = "https://github.com/asdf-community/asdf-clojure.git"
 
 [tools]
 clojure = "1.12"
-java = "graalvm-22.3.1+java11"
+java = "corretto-25"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 This is a history of changes to gateless/futurama
 
+# 1.4.4
+* **Dispatch**: `async-dispatch-task-handler` now accepts any `java.util.concurrent.Executor` (previously required `ExecutorService`). Tasks are wrapped in a `FutureTask` so cancel-with-interrupt and exception-capture semantics are preserved. Required to support core.async 1.9's `clojure.core.async.impl.dispatch/executor-for`, which returns a plain `Executor`.
+* **Default pool**: `get-pool` now falls back to `clojure.core.async.impl.dispatch/executor-for` (was `ForkJoinPool/commonPool`). Out of the box, futurama dispatches over the same workload-aware pools as core.async — no `futurama.executor-factory` sysprop required for that behavior. The sysprop remains the override hook.
+* **Tooling**: Bumped CI and `.mise.toml` JDK to corretto-25 (latest LTS); updated `.mise.toml` to the new `[tool_alias]` schema; default `TEST_CORE_ASYNC_ALIAS` flipped to `core.async-1.9` in the Makefile.
+
 # 1.4.3
 * **Dependencies**: Updated core.async to stable 1.9.865 (default), Clojure to 1.12.4, manifold to 0.5.0, Caffeine to 3.2.3.
 * **Tooling**: Updated clj-kondo to 2026.04.15 and kaocha to 1.91.1392.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: repl test clean deploy install format-check format-fix
 
 TEST_CLOJURE_ALIAS ?= clojure-1.12
-TEST_CORE_ASYNC_ALIAS ?= core.async-1.8
+TEST_CORE_ASYNC_ALIAS ?= core.async-1.9
 
 REPL_CLOJURE_ALIAS ?= clojure-1.12
-REPL_CORE_ASYNC_ALIAS ?= core.async-1.8
+REPL_CORE_ASYNC_ALIAS ?= core.async-1.9
 
 SHELL := /bin/bash
 JAVA_OPTS ?= -Dfuturama.executor-factory=clojure.core.async.impl.dispatch/executor-for

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Configure application-wide thread pools using the Java system property `futurama
                     "clojure.core.async.impl.dispatch/executor-for")
 ```
 
-The factory function receives a keyword (`:io`, `:compute`, `:mixed`) and should return an `ExecutorService` or `nil` to use defaults.
+The factory function receives a keyword (`:io`, `:compute`, `:mixed`) and should return an `Executor` or `nil` to use defaults.
 
 ### Exception Handling
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.gateless</groupId>
   <artifactId>futurama</artifactId>
   <name>futurama</name>
-  <version>1.4.3</version>
+  <version>1.4.4</version>
   <scm>
-    <tag>1.4.3</tag>
+    <tag>1.4.4</tag>
     <url>https://github.com/gateless/futurama</url>
     <connection>scm:git:git://github.com/gateless/futurama.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/gateless/futurama.git</developerConnection>

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -1,12 +1,10 @@
 (ns futurama.core
   "Futurama is a Clojure library for more deeply integrating async abstractions in the Clojure and JVM ecosystem with Clojure.
-
-  async and thread blocks are dispatched over an internal thread pool,
-  which defaults to using the `ForkJoinPool/commonPool`. They work very
-  similarly to core.async go blocks and thread blocks. Notable different
-  ways are that, async and thread blocks will return Throwable values when
-  exceptions are uncaught, and that taking a value from an async result
-  using `!<!` or `!<!!` will reduce nested async values to a single result.
+  Async and thread blocks are dispatched over an internal thread pool.
+  They work very similarly to core.async go blocks and thread blocks.
+  Notable different ways are that, async and thread blocks will return caught
+  exceptions, and that taking a value from an async result using `!<!` or `!<!!`
+  will reduce nested async values to a single result.
 
   The dynamic variables `*async-factory*` and `*thread-factory*` can be bound
   to control which async result type is returned when the `async` or `thread`
@@ -20,11 +18,12 @@
   - `async-deferred-factory`: creates a manifold deferred result.
   - `async-future-factory`: creates a CompletableFuture result.
 
+  By default, futurama will defer to a user factory (if provided via sys prop `futurama.executor-factory`)
+  or the using the same pool as core.async via `clojure.core.async.impl.dispatch/executor-for`
+
   Use the Java system property `futurama.executor-factory`
   to specify a function that will provide an Executor for
   application-wide use by futurama in lieu of its defaults.
-  To ensure that futurama uses the same thread pool as core.async,
-  you can set the property to the value `clojure.core.async.impl.dispatch/executor-for`.
   The property value should name a fully qualified var. The function
   will be passed a keyword indicating the context of use of the
   executor, and should return either an Executor, or nil to
@@ -66,7 +65,6 @@
             ExecutionException
             CancellationException
             Executor
-            ForkJoinPool
             Future]
            [java.util.concurrent.locks Lock]
            [java.util.function BiConsumer]
@@ -150,17 +148,15 @@
 
 (def get-pool
   "Given a workload tag, returns an Executor instance and memoizes the result.
-  By default, futurama will defer to a user factory (if provided via sys prop)
-  or the `ForkJoinPool/commonPool` instance. When using core.async 1.7 or higher it's possible to
-  set the `futurama.executor-factory` property to `clojure.core.async.impl.dispatch/executor-for`
-  and futurama will use the same pools as core.async."
+  By default, futurama will defer to a user factory (if provided via sys prop `futurama.executor-factory`)
+  or the using the same pool as core.async via `clojure.core.async.impl.dispatch/executor-for`"
   (memoize
    (fn ^Executor [workload]
      (let [sysprop-factory (when-let [esf (System/getProperty "futurama.executor-factory")]
                              (requiring-resolve (symbol esf)))
            sp-exec (and sysprop-factory (sysprop-factory workload))]
        (or sp-exec
-           (ForkJoinPool/commonPool))))))
+           (run-impl/executor-for workload))))))
 
 (defmacro with-pool
   "Utility macro which binds *thread-pool* to the supplied pool and then evaluates the `body`.

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -21,13 +21,13 @@
   - `async-future-factory`: creates a CompletableFuture result.
 
   Use the Java system property `futurama.executor-factory`
-  to specify a function that will provide ExecutorServices for
+  to specify a function that will provide an Executor for
   application-wide use by futurama in lieu of its defaults.
   To ensure that futurama uses the same thread pool as core.async,
   you can set the property to the value `clojure.core.async.impl.dispatch/executor-for`.
   The property value should name a fully qualified var. The function
   will be passed a keyword indicating the context of use of the
-  executor, and should return either an ExecutorService, or nil to
+  executor, and should return either an Executor, or nil to
   use the default. Results per keyword will be cached and used for
   the remainder of the application.
 
@@ -65,7 +65,7 @@
             CompletionException
             ExecutionException
             CancellationException
-            ExecutorService
+            Executor
             ForkJoinPool
             Future]
            [java.util.concurrent.locks Lock]
@@ -149,13 +149,13 @@
     (async-future-factory)))
 
 (def get-pool
-  "Given a workload tag, returns an ExecutorService instance and memoizes the result.
+  "Given a workload tag, returns an Executor instance and memoizes the result.
   By default, futurama will defer to a user factory (if provided via sys prop)
   or the `ForkJoinPool/commonPool` instance. When using core.async 1.7 or higher it's possible to
   set the `futurama.executor-factory` property to `clojure.core.async.impl.dispatch/executor-for`
   and futurama will use the same pools as core.async."
   (memoize
-   (fn ^ExecutorService [workload]
+   (fn ^Executor [workload]
      (let [sysprop-factory (when-let [esf (System/getProperty "futurama.executor-factory")]
                              (requiring-resolve (symbol esf)))
            sp-exec (and sysprop-factory (sysprop-factory workload))]
@@ -164,7 +164,7 @@
 
 (defmacro with-pool
   "Utility macro which binds *thread-pool* to the supplied pool and then evaluates the `body`.
-  The `pool` can be an ExecutorService or can also be a keyword/string to be passed to the `futurama.executor-factory`"
+  The `pool` can be an Executor or can also be a keyword/string to be passed to the `futurama.executor-factory`"
   [pool & body]
   `(let [pool# ~pool]
      (binding [*thread-pool* (if (keyword? pool#)

--- a/src/futurama/impl.clj
+++ b/src/futurama/impl.clj
@@ -1,5 +1,4 @@
 (ns ^:no-doc futurama.impl
-  (:refer-clojure :exclude [realized?])
   (:require
    [clojure.core.async :refer [take!]]
    [clojure.core.async.impl.go :as go-impl]
@@ -7,8 +6,9 @@
    [clojure.core.async.impl.protocols :as core-impl])
   (:import
    [java.util.concurrent
-    ExecutorService
-    Future]
+    Executor
+    Future
+    FutureTask]
    [java.util.concurrent.locks Lock]
    [java.util.function BiConsumer]))
 
@@ -42,8 +42,9 @@
 
 (defn async-dispatch-task-handler
   "Dispatches a task to the given executor service pool, and registers a cancellation handler on the port."
-  ^Future [^ExecutorService pool port ^Runnable task]
-  (let [^Future fut (.submit pool task)]
+  ^Future [^Executor pool port ^Runnable task]
+  (let [fut (FutureTask. ^Runnable task nil)]
+    (.execute pool fut)
     (on-cancel-interrupt port fut)
     port))
 


### PR DESCRIPTION
# Summary

Aligns futurama's dispatch with core.async 1.9, whose `executor-for` returns a plain `Executor` rather than an `ExecutorService`.

## Changes

- **Dispatch widened to `Executor`.** `async-dispatch-task-handler` now takes any `java.util.concurrent.Executor` instead of an `ExecutorService`. Tasks are wrapped in a `FutureTask` and submitted via `.execute`, preserving cancel-with-interrupt (atomic via `FutureTask`'s state machine — no leaked interrupts to recycled workers) and exception capture.
- **Default pool now matches core.async.** `get-pool` falls back to `clojure.core.async.impl.dispatch/executor-for` instead of `ForkJoinPool/commonPool`. Out of the box, futurama and core.async share the same workload-aware pools; the `futurama.executor-factory` sysprop remains as the override hook.
- **Tooling.** CI and `.mise.toml` JDK bumped to corretto-25 (latest LTS); `.mise.toml` migrated to the new `[tool_alias]` schema; default `TEST_CORE_ASYNC_ALIAS` flipped to `core.async-1.9`.

## Why

core.async 1.9's `executor-for` returns `Executor`, not `ExecutorService` — narrowing futurama's contract to match is what unblocks the 1.8 → 1.9 bump. Defaulting `get-pool` to `executor-for` removes a behavioral divergence that previously required a sysprop to fix.

## Compatibility

- Public API unchanged for callers passing an `ExecutorService` (it still satisfies `Executor`).
- Behavioral change for callers who relied on the implicit `ForkJoinPool/commonPool` default — they now get core.async's pool selection. Set `futurama.executor-factory` to the prior behavior if needed.