### PR TITLE
feat: coerce executor to executor service, add tests, release 1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 This is a history of changes to gateless/futurama
 
+# 1.4.6
+* **Pool contract**: `get-pool` once again returns an `ExecutorService` (1.4.5 had narrowed the return type to `Executor` to track core.async 1.9's `executor-for`, which broke downstream consumers that called `.submit`/`.invokeAll` on the pool). When `executor-for` returns a plain `Executor`, the result is widened via a new `futurama.impl/->executor-service` proxy that forwards `execute`; real `ExecutorService` instances pass through unwrapped. The internal `async-dispatch-task-handler` continues to accept any `Executor`.
+* **Proxy lifecycle**: The widening proxy throws `UnsupportedOperationException` from `shutdown`, `shutdownNow`, `isShutdown`, `isTerminated`, and `awaitTermination` — it does not own the underlying executor and refuses to lie about its lifecycle. Callers that need to manage a pool's lifecycle should hold a reference to the original `Executor` directly.
+* **Tests**: Added coverage for `->executor-service` (passthrough vs. wrap, `execute`/`submit` routing, lifecycle behavior on both branches) and for the previously-untested `with-async-factory` and `with-thread-factory` macros (binding/restore, precedence, nesting, exception unwind).
+
 # 1.4.5
 * **Dispatch**: `async-dispatch-task-handler` now accepts any `java.util.concurrent.Executor` (previously required `ExecutorService`). Tasks are wrapped in a `FutureTask` so cancel-with-interrupt and exception-capture semantics are preserved. Required to support core.async 1.9's `clojure.core.async.impl.dispatch/executor-for`, which returns a plain `Executor`.
 * **Default pool**: `get-pool` now falls back to `clojure.core.async.impl.dispatch/executor-for` (was `ForkJoinPool/commonPool`). Out of the box, futurama dispatches over the same workload-aware pools as core.async — no `futurama.executor-factory` sysprop required for that behavior. The sysprop remains the override hook.

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.gateless</groupId>
   <artifactId>futurama</artifactId>
   <name>futurama</name>
-  <version>1.4.5</version>
+  <version>1.4.6</version>
   <scm>
-    <tag>1.4.5</tag>
+    <tag>1.4.6</tag>
     <url>https://github.com/gateless/futurama</url>
     <connection>scm:git:git://github.com/gateless/futurama.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/gateless/futurama.git</developerConnection>

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -47,28 +47,36 @@
   primarily during development. Invalid blocking calls will throw in
   go block threads - use Thread.setDefaultUncaughtExceptionHandler()
   to catch and handle."
-  (:require [clojure.core.async :as async]
-            [clojure.core.async.impl.dispatch :as run-impl]
-            [clojure.core.async.impl.protocols :as core-impl]
-            [clojure.core.async.impl.channels :refer [box]]
-            [clojure.core.async.impl.ioc-macros :as rt]
-            [clojure.core.reducers :as r]
-            [futurama.impl :as impl]
-            [futurama.state :as state]
-            [manifold.deferred :as d])
-  (:import [clojure.lang Var IDeref IPending IFn IAtom IRef]
-           [clojure.core.async.impl.channels ManyToManyChannel]
-           [clojure.core.async.impl.buffers PromiseBuffer]
-           [java.util.concurrent
-            CompletableFuture
-            CompletionException
-            ExecutionException
-            CancellationException
-            Executor
-            Future]
-           [java.util.concurrent.locks Lock]
-           [java.util.function BiConsumer]
-           [manifold.deferred Deferred]))
+  (:require
+   [clojure.core.async :as async]
+   [clojure.core.async.impl.channels :refer [box]]
+   [clojure.core.async.impl.dispatch :as run-impl]
+   [clojure.core.async.impl.ioc-macros :as rt]
+   [clojure.core.async.impl.protocols :as core-impl]
+   [clojure.core.reducers :as r]
+   [futurama.impl :as impl]
+   [futurama.state :as state]
+   [manifold.deferred :as d])
+  (:import
+   [clojure.core.async.impl.buffers PromiseBuffer]
+   [clojure.core.async.impl.channels ManyToManyChannel]
+   [clojure.lang
+    IAtom
+    IDeref
+    IFn
+    IPending
+    IRef
+    Var]
+   [java.util.concurrent
+    CancellationException
+    CompletableFuture
+    CompletionException
+    ExecutionException
+    Executor
+    Future]
+   [java.util.concurrent.locks Lock]
+   [java.util.function BiConsumer]
+   [manifold.deferred Deferred]))
 
 (def ^:const ASYNC_CANCELLED ::cancelled)
 
@@ -147,16 +155,23 @@
     (async-future-factory)))
 
 (def get-pool
-  "Given a workload tag, returns an Executor instance and memoizes the result.
+  "Given a workload tag, returns an ExecutorService instance and memoizes the result.
   By default, futurama will defer to a user factory (if provided via sys prop `futurama.executor-factory`)
-  or the using the same pool as core.async via `clojure.core.async.impl.dispatch/executor-for`"
+  or use the same pool as core.async via `clojure.core.async.impl.dispatch/executor-for`.
+
+  The result is always an ExecutorService — earlier versions of this library returned an
+  ExecutorService, and downstream consumers (e.g. `core.async/thread` calling `.submit`)
+  rely on that contract. core.async 1.9's `executor-for` returns a plain Executor, so when
+  necessary the value is widened via `futurama.impl/->executor-service`. See that function's
+  docstring for the lifecycle caveats of the wrapper."
   (memoize
    (fn ^Executor [workload]
      (let [sysprop-factory (when-let [esf (System/getProperty "futurama.executor-factory")]
                              (requiring-resolve (symbol esf)))
-           sp-exec (and sysprop-factory (sysprop-factory workload))]
-       (or sp-exec
-           (run-impl/executor-for workload))))))
+           ^Executor executor (if sysprop-factory
+                                (sysprop-factory workload)
+                                (run-impl/executor-for workload))]
+       (impl/->executor-service executor)))))
 
 (defmacro with-pool
   "Utility macro which binds *thread-pool* to the supplied pool and then evaluates the `body`.

--- a/src/futurama/impl.clj
+++ b/src/futurama/impl.clj
@@ -6,6 +6,8 @@
    [clojure.core.async.impl.protocols :as core-impl])
   (:import
    [java.util.concurrent
+    AbstractExecutorService
+    ExecutorService
     Executor
     Future
     FutureTask]
@@ -34,6 +36,46 @@
     "Returns true if this async operation has been cancelled.")
   (cancel! [this]
     "Attempts to cancel this async operation."))
+
+(defn ->executor-service
+  "Returns the input unchanged when it is already an ExecutorService; otherwise wraps it in
+  a proxy that forwards `execute` to the underlying Executor.
+
+  The wrapper exists because `get-pool` historically returned an ExecutorService and downstream
+  consumers (notably `core.async/thread`, which calls `.submit` on the pool) depend on that
+  contract. core.async 1.9's `executor-for` now returns a plain Executor, so without this
+  adapter those callers break.
+
+  Lifecycle methods (`shutdown`, `shutdownNow`, `isShutdown`, `isTerminated`, `awaitTermination`)
+  throw UnsupportedOperationException: this proxy does not own the underlying executor and
+  cannot honestly answer for its lifecycle. Callers that need to manage a pool's lifecycle
+  should hold onto and operate on the original Executor reference, not this wrapper."
+  ^ExecutorService [^Executor executor]
+  (if (instance? ExecutorService executor)
+    executor
+    (proxy [AbstractExecutorService] []
+      (execute [^Runnable command]
+        (.execute executor command))
+
+      (shutdown []
+        (throw (UnsupportedOperationException.
+                "shutdown not supported on a non-owning ExecutorService proxy")))
+
+      (shutdownNow []
+        (throw (UnsupportedOperationException.
+                "shutdownNow not supported on a non-owning ExecutorService proxy")))
+
+      (isShutdown []
+        (throw (UnsupportedOperationException.
+                "isShutdown not supported on a non-owning ExecutorService proxy")))
+
+      (isTerminated []
+        (throw (UnsupportedOperationException.
+                "isTerminated not supported on a non-owning ExecutorService proxy")))
+
+      (awaitTermination [_wait-timeout _wait-unit]
+        (throw (UnsupportedOperationException.
+                "awaitTermination not supported on a non-owning ExecutorService proxy"))))))
 
 (deftype JavaBiConsumer [f]
   BiConsumer

--- a/test/futurama/core_test.clj
+++ b/test/futurama/core_test.clj
@@ -8,9 +8,10 @@
                                    async-cancel! async-cancellable? async-completed?
                                    async-cancelled? async-every? async-for async-map
                                    async-postwalk async-prewalk async-reduce async-some
-                                   async? get-pool thread with-pool] :as f])
+                                   async? get-pool thread with-pool] :as f]
+            [futurama.impl :as impl])
   (:import [clojure.lang ExceptionInfo]
-           [java.util.concurrent CompletableFuture Executors]))
+           [java.util.concurrent CompletableFuture Executor ExecutorService Executors TimeUnit]))
 
 (defn async-fixture
   [f]
@@ -105,7 +106,7 @@
       (let [interrupted (atom false)
             a (promise)
             s (atom 0)
-            f (f/thread
+            f (thread
                 (try
                   (while (not (async-cancelled?)) ;;; this loop goes on infinitely until the thread is interrupted
                     (Thread/sleep 90)
@@ -131,7 +132,7 @@
       (let [interrupted (atom false)
             a (promise)
             s (atom 0)
-            f (f/async
+            f (async
                 (try
                   (while (not (async-cancelled?)) ;;; this loop goes on infinitely until the thread is interrupted
                     (Thread/sleep 90)
@@ -557,3 +558,130 @@
     (let [val ::foobar
           fut (f/->future val)]
       (is (= ::foobar @fut)))))
+
+(deftest ->executor-service-test
+  (testing "ExecutorService is returned identically (no double-wrapping)"
+    (let [es (Executors/newSingleThreadExecutor)]
+      (try
+        (is (identical? es (impl/->executor-service es)))
+        (finally
+          (.shutdown es)))))
+  (testing "plain Executor is wrapped and routes execute to the underlying executor"
+    (let [calls (atom 0)
+          last-runnable (atom nil)
+          ^Executor e (reify Executor
+                        (execute [_ r]
+                          (swap! calls inc)
+                          (reset! last-runnable r)
+                          (.run r)))
+          es (impl/->executor-service e)
+          ran (atom false)]
+      (is (instance? ExecutorService es))
+      (is (not (identical? e es)))
+      (.execute es ^Runnable #(reset! ran true))
+      (is (= 1 @calls))
+      (is (true? @ran))
+      (is (some? @last-runnable))))
+  (testing "submit on the wrapper routes through the underlying executor and returns a Future"
+    (let [calls (atom 0)
+          ^Executor e (reify Executor
+                        (execute [_ r]
+                          (swap! calls inc)
+                          (.run r)))
+          es (impl/->executor-service e)
+          fut (.submit es ^Callable (fn [] ::done))]
+      (is (= 1 @calls))
+      (is (= ::done (.get fut)))))
+  (testing "lifecycle methods throw UnsupportedOperationException on the wrapper"
+    (let [^Executor e (reify Executor (execute [_ r] (.run r)))
+          es (impl/->executor-service e)]
+      (is (thrown? UnsupportedOperationException (.shutdown es)))
+      (is (thrown? UnsupportedOperationException (.shutdownNow es)))
+      (is (thrown? UnsupportedOperationException (.isShutdown es)))
+      (is (thrown? UnsupportedOperationException (.isTerminated es)))
+      (is (thrown? UnsupportedOperationException
+                   (.awaitTermination es 1 TimeUnit/MILLISECONDS)))))
+  (testing "lifecycle methods on a real ExecutorService pass through unchanged"
+    (let [es (Executors/newSingleThreadExecutor)
+          wrapped (impl/->executor-service es)]
+      (is (false? (.isShutdown wrapped)))
+      (.shutdown wrapped)
+      (is (true? (.isShutdown wrapped)))
+      (is (true? (.awaitTermination wrapped 1 TimeUnit/SECONDS)))))
+  (testing "get-pool returns an ExecutorService for built-in workloads"
+    (doseq [workload [:io :mixed :compute]]
+      (is (instance? ExecutorService (get-pool workload))
+          (str "workload " workload " should yield an ExecutorService")))))
+
+(deftest with-async-factory-test
+  (testing "binds *async-factory* inside body and restores it after"
+    (let [prior f/*async-factory*
+          marker (fn marker-factory [] ::async-marker)
+          captured (atom nil)]
+      (f/with-async-factory marker
+        (reset! captured f/*async-factory*))
+      (is (identical? marker @captured))
+      (is (= ::async-marker (@captured)))
+      (is (identical? prior f/*async-factory*))))
+  (testing "f/async-factory inside the body uses the bound factory"
+    (let [marker (fn [] ::async-marker)]
+      (f/with-async-factory marker
+        (is (= ::async-marker (f/async-factory))))))
+  (testing "thread-factory falls back to *async-factory* when *thread-factory* is unbound"
+    (let [marker (fn [] ::async-marker)]
+      (f/with-async-factory marker
+        (binding [f/*thread-factory* nil]
+          (is (= ::async-marker (f/thread-factory)))))))
+  (testing "nested with-async-factory rebinds and unwinds correctly"
+    (let [outer (fn [] ::outer)
+          inner (fn [] ::inner)]
+      (f/with-async-factory outer
+        (is (= ::outer (f/async-factory)))
+        (f/with-async-factory inner
+          (is (= ::inner (f/async-factory))))
+        (is (= ::outer (f/async-factory))))))
+  (testing "nil binding is honored and async-factory falls back to async-promise-factory default"
+    (f/with-async-factory nil
+      (binding [f/*thread-factory* nil]
+        (is (f/async? (f/async-factory))))))
+  (testing "exceptions in body still restore the prior binding"
+    (let [prior f/*async-factory*]
+      (is (thrown? ExceptionInfo
+                   (f/with-async-factory (fn [] ::oops)
+                     (throw (ex-info "boom" {})))))
+      (is (identical? prior f/*async-factory*)))))
+
+(deftest with-thread-factory-test
+  (testing "binds *thread-factory* inside body and restores it after"
+    (let [prior f/*thread-factory*
+          marker (fn marker-factory [] ::thread-marker)
+          captured (atom nil)]
+      (f/with-thread-factory marker
+        (reset! captured f/*thread-factory*))
+      (is (identical? marker @captured))
+      (is (= ::thread-marker (@captured)))
+      (is (identical? prior f/*thread-factory*))))
+  (testing "f/thread-factory inside the body uses the bound factory and takes precedence over *async-factory*"
+    (let [t-marker (fn [] ::thread-marker)
+          a-marker (fn [] ::async-marker)]
+      (f/with-async-factory a-marker
+        (f/with-thread-factory t-marker
+          (is (= ::thread-marker (f/thread-factory)))))))
+  (testing "*async-factory* is unaffected by with-thread-factory"
+    (let [prior-async f/*async-factory*]
+      (f/with-thread-factory (fn [] ::thread-marker)
+        (is (identical? prior-async f/*async-factory*)))))
+  (testing "nested with-thread-factory rebinds and unwinds correctly"
+    (let [outer (fn [] ::outer)
+          inner (fn [] ::inner)]
+      (f/with-thread-factory outer
+        (is (= ::outer (f/thread-factory)))
+        (f/with-thread-factory inner
+          (is (= ::inner (f/thread-factory))))
+        (is (= ::outer (f/thread-factory))))))
+  (testing "exceptions in body still restore the prior binding"
+    (let [prior f/*thread-factory*]
+      (is (thrown? ExceptionInfo
+                   (f/with-thread-factory (fn [] ::oops)
+                     (throw (ex-info "boom" {})))))
+      (is (identical? prior f/*thread-factory*)))))


### PR DESCRIPTION
- Restores get-pool's pre-1.4.5 ExecutorService return type.
- A new futurama.impl/->executor-service proxy widens the result when needed (real ExecutorService instances pass through unchanged) and throws UnsupportedOperationException from every lifecycle method since it doesn't own the underlying executor.
- Adds tests for ->executor-service and for the previously-untested with-async-factory/with-thread-factory macros, and bumps the changelog to 1.4.6.