### PR TITLE
feat: inline satisfies? checks used internally, add async check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 This is a history of changes to gateless/futurama
 
+# 1.4.7
+* **Membership predicates**: Centralized the scattered `satisfies?` protocol checks behind inlining predicate macros in `futurama.impl` (`async?`, `async-channel?`, `async-completable-reader?`, `async-completable-writer?`, `async-cancellable?`), and switched `futurama.core`/`futurama.impl` call sites over to them. The public `futurama.core/async?` remains a function so it can still be passed as a higher-order value.
+* **Fast path**: `!<!` and `!<!!` now short-circuit non-async values, returning them directly without a channel round-trip; the argument expression is still evaluated exactly once.
+* **Tests**: Added coverage for the `!<!`/`!<!!` non-async fast path, including the single-evaluation guarantee for both non-async and async argument expressions.
+* **Dependencies**: Updated Clojure to 1.12.5 and Caffeine to 3.2.4.
+
 # 1.4.6
 * **Pool contract**: `get-pool` once again returns an `ExecutorService` (1.4.5 had narrowed the return type to `Executor` to track core.async 1.9's `executor-for`, which broke downstream consumers that called `.submit`/`.invokeAll` on the pool). When `executor-for` returns a plain `Executor`, the result is widened via a new `futurama.impl/->executor-service` proxy that forwards `execute`; real `ExecutorService` instances pass through unwrapped. The internal `async-dispatch-task-handler` continues to accept any `Executor`.
 * **Proxy lifecycle**: The widening proxy throws `UnsupportedOperationException` from `shutdown`, `shutdownNow`, `isShutdown`, `isTerminated`, and `awaitTermination` — it does not own the underlying executor and refuses to lie about its lifecycle. Callers that need to manage a pool's lifecycle should hold a reference to the original `Executor` directly.

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.4"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.5"}
         org.clojure/core.async {:mvn/version "1.9.865"}
         manifold/manifold {:mvn/version "0.5.0"}
-        com.github.ben-manes.caffeine/caffeine {:mvn/version "3.2.3"}}
+        com.github.ben-manes.caffeine/caffeine {:mvn/version "3.2.4"}}
 
  ;for more examples of aliases see: https://github.com/seancorfield/dot-clojure
  :aliases
  {:clojure-1.11 {:extra-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
-  :clojure-1.12 {:extra-deps {org.clojure/clojure {:mvn/version "1.12.4"}}}
+  :clojure-1.12 {:extra-deps {org.clojure/clojure {:mvn/version "1.12.5"}}}
 
   :core.async-1.8 {:extra-deps {org.clojure/core.async {:mvn/version "1.8.741"}}}
   :core.async-1.9 {:extra-deps {org.clojure/core.async {:mvn/version "1.9.865"}}}

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
   <groupId>com.github.gateless</groupId>
   <artifactId>futurama</artifactId>
   <name>futurama</name>
-  <version>1.4.6</version>
+  <version>1.4.7</version>
   <scm>
-    <tag>1.4.6</tag>
+    <tag>1.4.7</tag>
     <url>https://github.com/gateless/futurama</url>
     <connection>scm:git:git://github.com/gateless/futurama.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/gateless/futurama.git</developerConnection>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.12.4</version>
+      <version>1.12.5</version>
     </dependency>
     <dependency>
       <groupId>manifold</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.2.3</version>
+      <version>3.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/src/futurama/core.clj
+++ b/src/futurama/core.clj
@@ -212,7 +212,7 @@
 (defn async-cancellable?
   "Determines if v can be cancelled"
   [v]
-  (satisfies? impl/AsyncCancellable v))
+  (impl/async-cancellable? v))
 
 (defn async-cancel!
   "Cancels the async item."
@@ -231,25 +231,25 @@
        (some async-cancelled? state/*items*)
        false))
   ([item]
-   (when (satisfies? impl/AsyncCancellable item)
+   (when (impl/async-cancellable? item)
      (impl/cancelled? item))))
 
 (defn async-completed?
   "Checks if the provided `AsyncCompletableReader` instance is completed?"
   [x]
   (cond
-    (satisfies? impl/AsyncCompletableReader x)
+    (impl/async-completable-reader? x)
     (impl/completed? x)
 
-    (satisfies? core-impl/Channel x)
+    (impl/async-channel? x)
     (core-impl/closed? x)
 
     :else false))
 
 (defn async?
   "returns true if v instance satisfies? core.async's `ReadPort`"
-  ^Boolean [v]
-  (satisfies? core-impl/ReadPort v))
+  [v]
+  (impl/async? v))
 
 (defmacro thread!
   "Asynchronously invokes the body inside a pooled thread and return over a write port,
@@ -367,7 +367,7 @@
                              (.unlock handler)
                              take-cb))]
       (when-let [cb (commit-handler)]
-        (if (async? val)
+        (if (impl/async? val)
           (do
             (async/take! val (impl/async-reader-handler cb))
             nil)
@@ -418,7 +418,14 @@
   - Will return the raw value if it is not a ReadPort
   - Will fully read through any async result returned"
   [v]
-  `(<! (rdr ~v)))
+  (if (symbol? v)
+    `(if (impl/async? ~v)
+       (<! (rdr ~v))
+       ~v)
+    `(let [v# ~v]
+       (if (impl/async? v#)
+         (<! (rdr v#))
+         v#))))
 
 (defmacro !<!*
   "Like !<! but works with collections of async values"
@@ -438,7 +445,14 @@
   - Will return the raw value if it is not a ReadPort
   - Will fully read through any async result returned"
   [v]
-  `(<!! (rdr ~v)))
+  (if (symbol? v)
+    `(if (impl/async? ~v)
+       (<!! (rdr ~v))
+       ~v)
+    `(let [v# ~v]
+       (if (impl/async? v#)
+         (<!! (rdr v#))
+         v#))))
 
 (defmacro async-for
   "works like a for macro, but supports core.async operations.
@@ -914,7 +928,7 @@
     (instance? CompletableFuture val)
     val
 
-    (async? val)
+    (impl/async? val)
     (let [fut (CompletableFuture.)]
       (impl/on-cancel-interrupt fut val)
       (async

--- a/src/futurama/impl.clj
+++ b/src/futurama/impl.clj
@@ -37,6 +37,31 @@
   (cancel! [this]
     "Attempts to cancel this async operation."))
 
+(defmacro async?
+  "Returns true if the given value satisfies core.async's `ReadPort`."
+  [x]
+  `(satisfies? core-impl/ReadPort ~x))
+
+(defmacro async-channel?
+  "Returns true if the given value satisfies core.async's `Channel`."
+  [x]
+  `(satisfies? core-impl/Channel ~x))
+
+(defmacro async-completable-writer?
+  "Returns true if the given value is an async operation that can be completed (i.e., satisfies AsyncCompletableWriter)."
+  [x]
+  `(satisfies? AsyncCompletableWriter ~x))
+
+(defmacro async-completable-reader?
+  "Returns true if the given value is an async operation that can be read (i.e., satisfies AsyncCompletableReader)."
+  [x]
+  `(satisfies? AsyncCompletableReader ~x))
+
+(defmacro async-cancellable?
+  "Determines if v can be cancelled"
+  [x]
+  `(satisfies? AsyncCancellable ~x))
+
 (defn ->executor-service
   "Returns the input unchanged when it is already an ExecutorService; otherwise wraps it in
   a proxy that forwards `execute` to the underlying Executor.
@@ -92,7 +117,7 @@
 
 (defn- async-reader-handler*
   [cb val]
-  (if (satisfies? core-impl/ReadPort val)
+  (if (async? val)
     (take! val (partial async-reader-handler* cb))
     (cb val)))
 
@@ -113,7 +138,7 @@
       (cond
         (completed? x)
         (let [r (get! x)]
-          (if (satisfies? core-impl/ReadPort r)
+          (if (async? r)
             (do
               (take! r (async-reader-handler cb))
               nil)
@@ -129,7 +154,7 @@
   (when (nil? val)
     (throw (IllegalArgumentException. "Can't put nil on an async thing, close it instead!")))
   (let [^Lock handler handler]
-    (if (and (satisfies? AsyncCompletableReader x)
+    (if (and (async-completable-reader? x)
              (completed? x))
       (do
         (.lock handler)

--- a/test/futurama/core_test.clj
+++ b/test/futurama/core_test.clj
@@ -509,6 +509,35 @@
                                            (CompletableFuture/completedFuture {:foo "bar"}))
                                   p)))))))))))))))
 
+(deftest non-async-fast-path
+  ;; !<! / !<!! short-circuit non-async values, returning them directly without
+  ;; a channel round-trip. These guard that behavior, including that the
+  ;; argument expression is evaluated exactly once (macro hygiene).
+  (testing "!<!! returns nil for a nil value"
+    (is (nil? (!<!! nil))))
+  (testing "!<!! returns a raw scalar unchanged"
+    (is (= 42 (!<!! 42))))
+  (testing "!<! returns nil for a nil value"
+    (is (nil? (<!! (async (!<! nil))))))
+  (testing "!<! returns a raw scalar unchanged"
+    (is (= 42 (<!! (async (!<! 42))))))
+  (testing "!<!! evaluates a non-async argument expression exactly once"
+    (let [calls (atom 0)]
+      (is (= 1 (!<!! (swap! calls inc))))
+      (is (= 1 @calls))))
+  (testing "!<! evaluates a non-async argument expression exactly once"
+    (let [calls (atom 0)]
+      (is (= 1 (<!! (async (!<! (swap! calls inc))))))
+      (is (= 1 @calls))))
+  (testing "!<!! evaluates an async argument expression exactly once"
+    (let [calls (atom 0)]
+      (is (= 1 (!<!! (async (swap! calls inc)))))
+      (is (= 1 @calls))))
+  (testing "!<! evaluates an async argument expression exactly once"
+    (let [calls (atom 0)]
+      (is (= 1 (<!! (async (!<! (async (swap! calls inc)))))))
+      (is (= 1 @calls)))))
+
 (deftest error-handling
   (testing "throws async exception on blocking take from thread - !<!!"
     (is (thrown-with-msg?


### PR DESCRIPTION
Inline the satisfies? protocol-membership checks behind centralized predicate macros in futurama.impl, add a non-async fast path to !<!/!<!!, bump Clojure/Caffeine, and add tests for the fast path's single-evaluation behavior.